### PR TITLE
chore(lints) fix clippy warnings in env var interpolation code

### DIFF
--- a/src/variable_interpolation/error.rs
+++ b/src/variable_interpolation/error.rs
@@ -1,6 +1,6 @@
 //! contains the error type used by the variable interpolation parser
 //!
-//! since the calling code expects the error type to be serde_yaml::Error,
+//! since the calling code expects the error type to be `serde_yaml::Error`,
 //! `ParseError` can be converted to that type, using the error information
 //! to construct a custom error message
 

--- a/src/variable_interpolation/parser.rs
+++ b/src/variable_interpolation/parser.rs
@@ -284,9 +284,10 @@ impl<'s> Parser<'s> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
+    // false positive: variable placeholders look a lot like rust formatting args
+    #![allow(clippy::literal_string_with_formatting_args)]
     use crate::variable_interpolation::{parser::Parser, VariableResolver};
+    use std::collections::HashMap;
 
     #[test]
     fn blank_strings() {


### PR DESCRIPTION
- allow literal_string_with_formatting_args in interpolation test code
- fix warning due to missing backticks